### PR TITLE
Adding option to allow `open_dir` to use `fzf-lua` instead of `telescope`

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ If you are building a plugin that requires the utilities provided by `utils.nvim
                 -- provider for results from `open_dir`
                 -- can be either 'telescope' or 'fzf_lua'
                 -- defaults to 'telescope'
-                open_dir_provider = "telescope"
+                fuzzy_provider = "telescope"
             }
         }
     },
@@ -82,11 +82,11 @@ If you are building a plugin that requires the utilities provided by `utils.nvim
 
 -- using `setup` function:
 require("utils").setup({
-    open_dir_provider = "telescope"
+    fuzzy_provider = "telescope"
 })
 ```
 
-Currently, there is only a single configurable option `open_dir_provider` which allows the user to switch the backend for the `open_dir` function provided by the plugin. The default is to use Telescope, with the option of switching to fzf-lua instead.
+Currently, there is only a single configurable option `fuzzy_provider` which allows the user to switch the backend for the `open_dir` function provided by the plugin. The default is to use Telescope, with the option of switching to fzf-lua instead.
 
 ## 🚀 Usage
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,35 @@ If you are building a plugin that requires the utilities provided by `utils.nvim
 },
 ```
 
+#### ⚙️ Configuration
+
+`utils.nvim` can optionally be configured by specifying `opts` with Lazy or alternatively with the `setup` function like so:
+
+```lua
+-- Lazy:
+{
+    'yourname/plugin.nvim',
+    dependencies = {
+        {
+            '2kabhishek/utils.nvim',
+            opts = {
+                -- provider for results from `open_dir`
+                -- can be either 'telescope' or 'fzf_lua'
+                -- defaults to 'telescope'
+                open_dir_provider = "telescope"
+            }
+        }
+    },
+}
+
+-- using `setup` function:
+require("utils").setup({
+    open_dir_provider = "telescope"
+})
+```
+
+Currently, there is only a single configurable option `open_dir_provider` which allows the user to switch the backend for the `open_dir` function provided by the plugin. The default is to use Telescope, with the option of switching to fzf-lua instead.
+
 ## 🚀 Usage
 
 ### Functions

--- a/doc/utils.txt
+++ b/doc/utils.txt
@@ -1,4 +1,4 @@
-*utils.txt*          For Neovim >= 0.8.0         Last change: 2024 December 01
+*utils.txt*          For Neovim >= 0.8.0         Last change: 2024 December 23
 
 ==============================================================================
 Table of Contents                                    *utils-table-of-contents*

--- a/lua/utils.lua
+++ b/lua/utils.lua
@@ -29,6 +29,26 @@ M.setup = function(opts)
   end
 end
 
+---@return string
+local function get_open_command(is_git_repo, dir)
+  local commands = {
+    git = {
+      telescope = 'Telescope git_files cwd=',
+      fzf_lua = 'FzfLua git_files cwd=',
+    },
+    no_git = {
+      telescope = 'Telescope find_files',
+      fzf_lua = 'FzfLua files',
+    },
+  }
+
+  if is_git_repo then
+    return commands.git[M.fuzzy_provider] .. (dir or '')
+  else
+    return commands.no_git[M.fuzzy_provider]
+  end
+end
+
 ---@type table<number, {message: string, level: number, title: string, timeout: number}>
 local notification_queue = {}
 
@@ -138,15 +158,7 @@ M.open_dir = function(dir)
 
     local is_git_repo = vim.fn.system('git rev-parse --is-inside-work-tree 2>/dev/null'):match('true')
 
-    if is_git_repo and M.fuzzy_provider == "telescope" then
-      vim.cmd('Telescope git_files cwd=' .. dir)
-    elseif is_git_repo and M.fuzzy_provider == "fzf_lua" then
-      vim.cmd('FzfLua git_files cwd=' .. dir)
-    elseif M.fuzzy_provider == "telescope" then
-      vim.cmd('Telescope find_files')
-    else
-      vim.cmd('FzfLua files')
-    end
+    vim.cmd(get_open_command(is_git_repo, dir))
   end)
 end
 

--- a/lua/utils.lua
+++ b/lua/utils.lua
@@ -19,13 +19,13 @@ local os = require('os')
 ---@class Utils
 local M = {}
 
----@field open_dir_provider string
-M.open_dir_provider = "telescope"
+---@field fuzzy_provider string
+M.fuzzy_provider = "telescope"
 
 ---@param opts table | nil
 M.setup = function(opts)
-  if opts.open_dir_provider then
-    M.open_dir_provider = opts.open_dir_provider
+  if opts.fuzzy_provider then
+    M.fuzzy_provider = opts.fuzzy_provider
   end
 end
 
@@ -122,8 +122,8 @@ end
 
 ---@param dir string
 M.open_dir = function(dir)
-  if M.open_dir_provider ~= "telescope" and M.open_dir_provider ~= "fzf_lua" then
-    error("Invalid `open_dir_provider`: " .. M.open_dir_provider .. "\nPlease use either 'telescope' or 'fzf_lua'.")
+  if M.fuzzy_provider ~= "telescope" and M.fuzzy_provider ~= "fzf_lua" then
+    error("Invalid `fuzzy_provider`: " .. M.fuzzy_provider .. "\nPlease use either 'telescope' or 'fzf_lua'.")
   end
 
   if inside_tmux then
@@ -138,11 +138,11 @@ M.open_dir = function(dir)
 
     local is_git_repo = vim.fn.system('git rev-parse --is-inside-work-tree 2>/dev/null'):match('true')
 
-    if is_git_repo and M.open_dir_provider == "telescope" then
+    if is_git_repo and M.fuzzy_provider == "telescope" then
       vim.cmd('Telescope git_files cwd=' .. dir)
-    elseif is_git_repo and M.open_dir_provider == "fzf_lua" then
+    elseif is_git_repo and M.fuzzy_provider == "fzf_lua" then
       vim.cmd('FzfLua git_files cwd=' .. dir)
-    elseif M.open_dir_provider == "telescope" then
+    elseif M.fuzzy_provider == "telescope" then
       vim.cmd('Telescope find_files')
     else
       vim.cmd('FzfLua files')

--- a/tests/utils_spec.lua
+++ b/tests/utils_spec.lua
@@ -152,16 +152,12 @@ describe('utils', function()
 
         it('handles tmux environment for open_dir', function()
             local original_execute = os.execute
-            local execute_called = false
             os.execute = function(cmd)
-                execute_called = true
                 return 1 -- Simulate failure to fall back to Telescope
             end
 
             local original_schedule = vim.schedule
-            local schedule_called = false
             vim.schedule = function(callback)
-                schedule_called = true
                 callback()
             end
 
@@ -171,13 +167,12 @@ describe('utils', function()
                 table.insert(cmd_calls, command)
             end
 
-            utils.open_dir('test/dir')
+            local test_dir = 'test/dir'
+            utils.open_dir(test_dir)
 
-            assert.is_true(execute_called)
-            assert.is_true(schedule_called)
             assert.equal(2, #cmd_calls)
-            assert.equal('cd test/dir', cmd_calls[1])
-            assert.equal('Telescope git_files', cmd_calls[2])
+            assert.equal('cd ' .. test_dir, cmd_calls[1])
+            assert.equal('Telescope git_files cwd=' .. test_dir, cmd_calls[2])
 
             -- Cleanup
             os.execute = original_execute


### PR DESCRIPTION
## What

What does this pull request accomplish?

- [x] Adds an option `open_dir_provider` which allows the user to configure the plugin to use `fzf-lua` instead of `telescope` for the function `open_dir`. This defaults to 'telescope'.
- [x] Updates the readme to reflect this change.

## How

What code changes were made to accomplish it?

- Added a `setup` function which can be used to override a new option `open_dir_provider`. This default to 'telescope'.
- To use `fzf-lua` instead one can set `open_dir_provider = 'fzf_lua'` instead.

## Why

- [x] I want to add a new feature as mentioned in #1.


# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
