### PR TITLE
Adding support for Snacks as `fuzzy_provider`

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ If you are building a plugin that requires the utilities provided by `utils.nvim
             '2kabhishek/utils.nvim',
             opts = {
                 -- provider for results from `open_dir`
-                -- can be either 'telescope' or 'fzf_lua'
+                -- can be either 'telescope', 'fzf_lua', or 'snacks'
                 -- defaults to 'telescope'
                 fuzzy_provider = "telescope"
             }
@@ -86,7 +86,7 @@ require("utils").setup({
 })
 ```
 
-Currently, there is only a single configurable option `fuzzy_provider` which allows the user to switch the backend for the `open_dir` function provided by the plugin. The default is to use Telescope, with the option of switching to fzf-lua instead.
+Currently, there is only a single configurable option `fuzzy_provider` which allows the user to switch the backend for the `open_dir` function provided by the plugin. The default is to use Telescope, with the option of switching to fzf-lua or snacks instead.
 
 ## 🚀 Usage
 


### PR DESCRIPTION
## What does the PR do? (Required)

- [x] Adds support for using [Snacks file picker](https://github.com/folke/snacks.nvim/blob/main/docs/picker.md) as the `fuzzy_provider`.

This is accomplished by changing `get_open_command` to return a **function** instead of a cmd string which is then called directly in `open_dir`. I do not believe Snacks.nvim provides autocmds for their pickers. I had also considered making the return type of `get_open_command` be a string or a function depending on the `fuzzy_provider` and then checking the type in `open_dir`. This seemed messier to me so I changed it to the proposed changes instead.

## Checklist (Required)

- [x] I have tested the changes on my local machine
- [x] I have added relevant documentation and tests for the changes
- [x] I have followed the style guidelines of this project

## Evidence (Required)

The tests ran successfully with `make` in my local copy. However, I am still running into the issue of this test failing (just as in #2):

```
Fail    ||      utils human_time converts timestamp to human readable format
            .../yanni/projects/nvim-dev/utils.nvim/tests/utils_spec.lua:268: Expected objects to be equal.
            Passed in:
            (string) '05 Oct 2024, 03:46 pm'
            Expected:
            (string) '05 Oct 2024, 03:46 PM'

            stack traceback:
                .../yanni/projects/nvim-dev/utils.nvim/tests/utils_spec.lua:268: in function <.../yanni/projects/nvim-dev/utils.nvim/tests/utils_spec.lua:263>
```
I do not believe this has any relation to the changes proposed here.
